### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   ast_viewer:
-    github: arcage/ast_viewer
+    github: arcage/ast_viewer.cr
 ```
 
 ## Usage


### PR DESCRIPTION
The name of the dependency was missing the last part `cr` so it was't found when running `shards install`